### PR TITLE
[Feat] 새 자취/하숙 데이터 등록 api 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,8 @@ dependencies {
 	implementation 'javax.xml.bind:jaxb-api:2.3.1'
 	// redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	// s3
+	implementation "io.awspring.cloud:spring-cloud-aws-starter-s3"
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ dependencies {
 	// redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	// s3
+	implementation platform("io.awspring.cloud:spring-cloud-aws-dependencies:3.0.1")
 	implementation "io.awspring.cloud:spring-cloud-aws-starter-s3"
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/efub/livin/global/exception/ErrorCode.java
+++ b/src/main/java/com/efub/livin/global/exception/ErrorCode.java
@@ -6,7 +6,11 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum ErrorCode {
-    UNAUTHORIZED_ACCESS(401, "인증되지 않은 사용자입니다.");
+    UNAUTHORIZED_ACCESS(401, "인증되지 않은 사용자입니다."),
+
+    // House 저장 관련
+    KAKAO_API_ERROR(500, "카카오 API 연동 중 오류가 발생했습니다."),
+    KAKAO_API_EMPTY_RESPONSE(500, "카카오 API로부터 빈 응답을 받았습니다.");
 
     private final int status;
     private final String message;

--- a/src/main/java/com/efub/livin/house/controller/HouseController.java
+++ b/src/main/java/com/efub/livin/house/controller/HouseController.java
@@ -1,0 +1,29 @@
+package com.efub.livin.house.controller;
+
+import com.efub.livin.house.domain.House;
+import com.efub.livin.house.dto.request.HouseCreateRequest;
+import com.efub.livin.house.dto.response.HouseResponse;
+import com.efub.livin.house.service.HouseService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/house")
+public class HouseController {
+
+    private final HouseService houseService;
+
+    // 새 자취/하숙 생성 컨트롤러
+    @PostMapping(value = "/new")
+    public ResponseEntity<HouseResponse> save(@Valid @RequestBody HouseCreateRequest request) {
+        HouseResponse response = houseService.addHouse(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+}

--- a/src/main/java/com/efub/livin/house/controller/HouseController.java
+++ b/src/main/java/com/efub/livin/house/controller/HouseController.java
@@ -7,11 +7,12 @@ import com.efub.livin.house.service.HouseService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
 
 @RestController
 @RequiredArgsConstructor
@@ -22,7 +23,9 @@ public class HouseController {
 
     // 새 자취/하숙 생성 컨트롤러
     @PostMapping(value = "/new")
-    public ResponseEntity<HouseResponse> save(@Valid @RequestBody HouseCreateRequest request) {
+    public ResponseEntity<HouseResponse> save(
+            @Valid @RequestBody HouseCreateRequest request) {
+
         HouseResponse response = houseService.addHouse(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }

--- a/src/main/java/com/efub/livin/house/controller/ImageController.java
+++ b/src/main/java/com/efub/livin/house/controller/ImageController.java
@@ -1,0 +1,29 @@
+package com.efub.livin.house.controller;
+
+import com.efub.livin.house.service.ImageService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/house/image")
+public class ImageController {
+
+    private final ImageService imageService;
+
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<String> uploadImage(@RequestParam("image") MultipartFile file) throws IOException {
+
+        String s3Url = imageService.upload(file, "house");
+        return ResponseEntity.ok(s3Url);
+    }
+
+}

--- a/src/main/java/com/efub/livin/house/domain/House.java
+++ b/src/main/java/com/efub/livin/house/domain/House.java
@@ -21,20 +21,19 @@ public class House {
     private String lat; // 위도
     private String place_url; // 상세 페이지 URL
     private String docId; // 지도 자체 장소 id
-    @Column(name = "`floor`")
     private Integer floor;
     private Boolean parking;
-    @Column(name = "`options`")
     private String options;
+
+    @Column(columnDefinition = "TEXT")
     private String imageUrl;
+
     // 가격대
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "`type`")
     private HouseType type; // 자취방 PRIVATE, 하숙 BOARDING
 
     // 리뷰 관련
-    @Column(name = "`rate`")
     private float rate;
 
     // 리뷰 관계 코드

--- a/src/main/java/com/efub/livin/house/domain/House.java
+++ b/src/main/java/com/efub/livin/house/domain/House.java
@@ -1,5 +1,6 @@
 package com.efub.livin.house.domain;
 
+import com.efub.livin.house.dto.request.HouseCreateRequest;
 import jakarta.persistence.*;
 import lombok.Getter;
 
@@ -20,15 +21,16 @@ public class House {
     private float lon; // 경도
     private String place_url; // 상세 페이지 URL
     private String docId; // 지도 자체 장소 id
+    private Integer floor;
+    private Boolean parking;
+    private String options;
+    // 가격대
 
     @Enumerated(EnumType.STRING)
     private HouseType type; // 자취방 PRIVATE, 하숙 BOARDING
 
     // 리뷰 관련
     private float rate;
-    private int floor;
-    //private enum option;
-    private boolean parking;
 
     // 리뷰 관계 코드
 
@@ -42,7 +44,18 @@ public class House {
         house.lon = Float.parseFloat(dto.getY());
         house.docId = dto.getId();
         house.type = type;
+        return house;
+    }
 
+    //
+    public static House create(HouseCreateRequest request){
+        House house = new House();
+        house.type = request.getType();
+        house.buildingName = request.getBuildingName();
+        house.address = request.getAddress();
+        house.options = request.getOptions();
+        house.parking = request.getParking();
+        // 위도, 경도 추가 로직
         return house;
     }
 

--- a/src/main/java/com/efub/livin/house/domain/House.java
+++ b/src/main/java/com/efub/livin/house/domain/House.java
@@ -24,6 +24,7 @@ public class House {
     private Integer floor;
     private Boolean parking;
     private String options;
+    private String imageUrl;
     // 가격대
 
     @Enumerated(EnumType.STRING)
@@ -35,7 +36,7 @@ public class House {
     // 리뷰 관계 코드
 
     // Document dto -> House 엔티티로 변환
-    public static House from(Document dto, HouseType type){
+    public static House from(Document dto, HouseType type, String imageUrl){
         House house = new House();
         house.buildingName = dto.getPlace_name();
         house.address = dto.getAddress_name();
@@ -44,10 +45,11 @@ public class House {
         house.lon = Float.parseFloat(dto.getY());
         house.docId = dto.getId();
         house.type = type;
+        house.imageUrl = imageUrl;
         return house;
     }
 
-    //
+    // 새 자취/하숙 데이터 저장용
     public static House create(HouseCreateRequest request){
         House house = new House();
         house.type = request.getType();

--- a/src/main/java/com/efub/livin/house/domain/House.java
+++ b/src/main/java/com/efub/livin/house/domain/House.java
@@ -16,22 +16,25 @@ public class House {
 
     private String buildingName;
     private String address;
-    private String image;
     private String phone; // 대표 번호
-    private String lat; // 위도
     private String lon; // 경도
+    private String lat; // 위도
     private String place_url; // 상세 페이지 URL
     private String docId; // 지도 자체 장소 id
+    @Column(name = "`floor`")
     private Integer floor;
     private Boolean parking;
+    @Column(name = "`options`")
     private String options;
     private String imageUrl;
     // 가격대
 
     @Enumerated(EnumType.STRING)
+    @Column(name = "`type`")
     private HouseType type; // 자취방 PRIVATE, 하숙 BOARDING
 
     // 리뷰 관련
+    @Column(name = "`rate`")
     private float rate;
 
     // 리뷰 관계 코드
@@ -51,14 +54,16 @@ public class House {
     }
 
     // 새 자취/하숙 데이터 저장용
-    public static House create(HouseCreateRequest request){
+    public static House create(HouseCreateRequest request, String lon, String lat){
         House house = new House();
         house.type = request.getType();
         house.buildingName = request.getBuildingName();
         house.address = request.getAddress();
         house.options = request.getOptions();
         house.parking = request.getParking();
-        // 위도, 경도 추가 로직
+        house.imageUrl = request.getImageUrl();
+        house.lon = lon;
+        house.lat = lat;
         return house;
     }
 

--- a/src/main/java/com/efub/livin/house/domain/House.java
+++ b/src/main/java/com/efub/livin/house/domain/House.java
@@ -3,9 +3,10 @@ package com.efub.livin.house.domain;
 import com.efub.livin.house.dto.request.HouseCreateRequest;
 import jakarta.persistence.*;
 import lombok.Getter;
+import lombok.Setter;
 
 @Entity
-@Getter
+@Getter @Setter
 @Table(name = "house")
 public class House {
 
@@ -17,8 +18,8 @@ public class House {
     private String address;
     private String image;
     private String phone; // 대표 번호
-    private float lat; // 위도
-    private float lon; // 경도
+    private String lat; // 위도
+    private String lon; // 경도
     private String place_url; // 상세 페이지 URL
     private String docId; // 지도 자체 장소 id
     private Integer floor;
@@ -40,8 +41,8 @@ public class House {
         house.buildingName = dto.getPlace_name();
         house.address = dto.getAddress_name();
         house.phone = dto.getPhone();
-        house.lat = Float.parseFloat(dto.getX());
-        house.lon = Float.parseFloat(dto.getY());
+        house.lon = dto.getX();
+        house.lat = dto.getY();
         house.docId = dto.getId();
         house.type = type;
         return house;

--- a/src/main/java/com/efub/livin/house/domain/Item.java
+++ b/src/main/java/com/efub/livin/house/domain/Item.java
@@ -1,0 +1,14 @@
+package com.efub.livin.house.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true) // thumbnail 외 다른 필드 무시
+public class Item {
+
+    // 네이버 응답의 이미지 주소 키 thumbnail
+    private String thumbnail;
+}

--- a/src/main/java/com/efub/livin/house/dto/request/HouseCreateRequest.java
+++ b/src/main/java/com/efub/livin/house/dto/request/HouseCreateRequest.java
@@ -1,0 +1,23 @@
+package com.efub.livin.house.dto.request;
+
+import com.efub.livin.house.domain.HouseType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class HouseCreateRequest {
+
+    @NotNull
+    private HouseType type;
+
+    @NotBlank
+    private String buildingName;
+
+    private String address;
+    private Boolean parking;
+    private String options;
+
+}

--- a/src/main/java/com/efub/livin/house/dto/request/HouseCreateRequest.java
+++ b/src/main/java/com/efub/livin/house/dto/request/HouseCreateRequest.java
@@ -19,5 +19,6 @@ public class HouseCreateRequest {
     private String address;
     private Boolean parking;
     private String options;
+    private String imageUrl;
 
 }

--- a/src/main/java/com/efub/livin/house/dto/response/HouseResponse.java
+++ b/src/main/java/com/efub/livin/house/dto/response/HouseResponse.java
@@ -17,6 +17,7 @@ public class HouseResponse {
     private Boolean parking;
     private HouseType type;
     private String options;
+    private String imageUrl;
 
     public static HouseResponse from(House house){
         HouseResponse response = new HouseResponse();
@@ -26,6 +27,7 @@ public class HouseResponse {
         response.type = house.getType();
         response.parking = house.getParking();
         response.options = house.getOptions();
+        response.imageUrl = house.getImageUrl();
         return response;
     }
 }

--- a/src/main/java/com/efub/livin/house/dto/response/HouseResponse.java
+++ b/src/main/java/com/efub/livin/house/dto/response/HouseResponse.java
@@ -19,6 +19,7 @@ public class HouseResponse {
     private String options;
     private String x; // 경도
     private String y; // 위도
+    private String imageUrl;
 
     public static HouseResponse from(House house){
         HouseResponse response = new HouseResponse();
@@ -30,7 +31,7 @@ public class HouseResponse {
         response.options = house.getOptions();
         response.x = house.getLon(); // 경도
         response.y = house.getLat(); // 위도
-
+        response.imageUrl = house.getImageUrl();
         return response;
     }
 }

--- a/src/main/java/com/efub/livin/house/dto/response/HouseResponse.java
+++ b/src/main/java/com/efub/livin/house/dto/response/HouseResponse.java
@@ -17,6 +17,8 @@ public class HouseResponse {
     private Boolean parking;
     private HouseType type;
     private String options;
+    private String x; // 경도
+    private String y; // 위도
 
     public static HouseResponse from(House house){
         HouseResponse response = new HouseResponse();
@@ -26,6 +28,9 @@ public class HouseResponse {
         response.type = house.getType();
         response.parking = house.getParking();
         response.options = house.getOptions();
+        response.x = house.getLon(); // 경도
+        response.y = house.getLat(); // 위도
+
         return response;
     }
 }

--- a/src/main/java/com/efub/livin/house/dto/response/HouseResponse.java
+++ b/src/main/java/com/efub/livin/house/dto/response/HouseResponse.java
@@ -1,0 +1,31 @@
+package com.efub.livin.house.dto.response;
+
+import com.efub.livin.house.domain.House;
+import com.efub.livin.house.domain.HouseType;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class HouseResponse {
+
+    private Long houseId;
+    private String buildingName;
+    private String address;
+    private Boolean parking;
+    private HouseType type;
+    private String options;
+
+    public static HouseResponse from(House house){
+        HouseResponse response = new HouseResponse();
+        response.houseId = house.getHouseId();
+        response.buildingName = house.getBuildingName();
+        response.address = house.getAddress();
+        response.type = house.getType();
+        response.parking = house.getParking();
+        response.options = house.getOptions();
+        return response;
+    }
+}

--- a/src/main/java/com/efub/livin/house/dto/response/KakaoResponseDto.java
+++ b/src/main/java/com/efub/livin/house/dto/response/KakaoResponseDto.java
@@ -1,4 +1,4 @@
-package com.efub.livin.house.dto;
+package com.efub.livin.house.dto.response;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/com/efub/livin/house/dto/response/NaverImageResponseDto.java
+++ b/src/main/java/com/efub/livin/house/dto/response/NaverImageResponseDto.java
@@ -1,0 +1,15 @@
+package com.efub.livin.house.dto.response;
+
+import com.efub.livin.house.domain.Item;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true) // items 외 다른 필드는 무시
+public class NaverImageResponseDto {
+    private List<Item> items; // Naver의 items 결과 리스트
+}

--- a/src/main/java/com/efub/livin/house/repository/HouseRepository.java
+++ b/src/main/java/com/efub/livin/house/repository/HouseRepository.java
@@ -1,0 +1,7 @@
+package com.efub.livin.house.repository;
+
+import com.efub.livin.house.domain.House;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface HouseRepository extends JpaRepository<House, Long> {
+}

--- a/src/main/java/com/efub/livin/house/service/HouseSaveService.java
+++ b/src/main/java/com/efub/livin/house/service/HouseSaveService.java
@@ -4,7 +4,7 @@ import com.efub.livin.house.domain.HouseType;
 import lombok.RequiredArgsConstructor;
 import com.efub.livin.house.domain.Document;
 import com.efub.livin.house.domain.House;
-import com.efub.livin.house.dto.KakaoResponseDto;
+import com.efub.livin.house.dto.response.KakaoResponseDto;
 import com.efub.livin.house.repository.HouseSaveRepository;
 import org.springframework.stereotype.Service;
 import java.util.List;
@@ -26,7 +26,6 @@ public class HouseSaveService {
         // 키워드별로 데이터 저장
         for(String keyword : KEYWORDS){
             KakaoResponseDto response = kakaoApiClient.searchByKeyword(keyword);
-            //KakaoResponseDto response = kakaoApiClient.searchByKeyword(keyword);
             List<Document> documents = response.getDocuments();
 
             if (documents == null || documents.isEmpty()) {

--- a/src/main/java/com/efub/livin/house/service/HouseSaveService.java
+++ b/src/main/java/com/efub/livin/house/service/HouseSaveService.java
@@ -33,7 +33,6 @@ public class HouseSaveService {
             List<Document> documents = response.getDocuments();
 
             if (documents == null || documents.isEmpty()) {
-                System.out.println(keyword + " 검색 결과 없음");
                 continue;
             }
 
@@ -43,7 +42,12 @@ public class HouseSaveService {
 
                 // 네이버 이미지 검색 호출
                 NaverImageResponseDto naverResponse = naverApiClient.searchImage(document.getPlace_name());
-
+                // Naver api 속도제한용 딜레이
+                try {
+                    Thread.sleep(100); // 0.1초 대기
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
                 // Naver 응답이 정상이면, thumbnail URL 추출
                 if (naverResponse != null && naverResponse.getItems() != null && !naverResponse.getItems().isEmpty()) {
                     imageUrl = naverResponse.getItems().get(0).getThumbnail();

--- a/src/main/java/com/efub/livin/house/service/HouseSaveService.java
+++ b/src/main/java/com/efub/livin/house/service/HouseSaveService.java
@@ -1,10 +1,11 @@
 package com.efub.livin.house.service;
 
 import com.efub.livin.house.domain.HouseType;
+import com.efub.livin.house.dto.response.NaverImageResponseDto;
 import lombok.RequiredArgsConstructor;
 import com.efub.livin.house.domain.Document;
 import com.efub.livin.house.domain.House;
-import com.efub.livin.house.dto.KakaoResponseDto;
+import com.efub.livin.house.dto.response.KakaoResponseDto;
 import com.efub.livin.house.repository.HouseSaveRepository;
 import org.springframework.stereotype.Service;
 import java.util.List;
@@ -17,6 +18,7 @@ import static com.efub.livin.house.domain.HouseType.PRIVATE;
 public class HouseSaveService {
 
     private final KakaoApiClient kakaoApiClient;
+    private final NaverApiClient naverApiClient;
     private final HouseSaveRepository houseSaveRepository;
 
     private static final List<String> KEYWORDS = List.of("자취", "고시원", "고시텔", "쉐어하우스", "하숙");
@@ -25,8 +27,9 @@ public class HouseSaveService {
 
         // 키워드별로 데이터 저장
         for(String keyword : KEYWORDS){
+
+            // 카카오 키워드별 검색 호출
             KakaoResponseDto response = kakaoApiClient.searchByKeyword(keyword);
-            //KakaoResponseDto response = kakaoApiClient.searchByKeyword(keyword);
             List<Document> documents = response.getDocuments();
 
             if (documents == null || documents.isEmpty()) {
@@ -36,6 +39,15 @@ public class HouseSaveService {
 
             for(Document document : documents){
                 HouseType type;
+                String imageUrl = null;
+
+                // 네이버 이미지 검색 호출
+                NaverImageResponseDto naverResponse = naverApiClient.searchImage(document.getPlace_name());
+
+                // Naver 응답이 정상이면, thumbnail URL 추출
+                if (naverResponse != null && naverResponse.getItems() != null && !naverResponse.getItems().isEmpty()) {
+                    imageUrl = naverResponse.getItems().get(0).getThumbnail();
+                }
 
                 if(keyword.equals("자취") || keyword.equals("고시원") || keyword.equals("고시텔")){
                     type = PRIVATE;
@@ -43,7 +55,7 @@ public class HouseSaveService {
                     type = BOARDING;
                 }
                 // House 엔티티로 변환
-                House house = House.from(document, type);
+                House house = House.from(document, type, imageUrl);
 
                 // DB에 저장
                 houseSaveRepository.save(house);

--- a/src/main/java/com/efub/livin/house/service/HouseService.java
+++ b/src/main/java/com/efub/livin/house/service/HouseService.java
@@ -1,6 +1,8 @@
 package com.efub.livin.house.service;
 
+import com.efub.livin.house.domain.Document;
 import com.efub.livin.house.domain.House;
+import com.efub.livin.house.dto.response.KakaoResponseDto;
 import com.efub.livin.house.dto.request.HouseCreateRequest;
 import com.efub.livin.house.dto.response.HouseResponse;
 import com.efub.livin.house.repository.HouseRepository;
@@ -13,11 +15,22 @@ import org.springframework.transaction.annotation.Transactional;
 public class HouseService {
 
     private final HouseRepository houseRepository;
+    private final KakaoApiClient kakaoApiClient;
 
     // 새 자취/하숙 정보 등록
     @Transactional
     public HouseResponse addHouse(HouseCreateRequest request){
         House house = House.create(request);
+
+        // 주소 -> 좌표 변환
+        KakaoResponseDto addressResponse = kakaoApiClient.searchAddress(request.getAddress());
+        if (addressResponse != null && addressResponse.getDocuments() != null && !addressResponse.getDocuments().isEmpty()) {
+            // 결과의 좌표를 엔티티에 저장
+            Document doc = addressResponse.getDocuments().get(0);
+            house.setLat(doc.getY()); // 위도
+            house.setLon(doc.getX()); // 경도
+        }
+
         House savedHouse = houseRepository.save(house);
 
         return HouseResponse.from(savedHouse);

--- a/src/main/java/com/efub/livin/house/service/HouseService.java
+++ b/src/main/java/com/efub/livin/house/service/HouseService.java
@@ -1,0 +1,25 @@
+package com.efub.livin.house.service;
+
+import com.efub.livin.house.domain.House;
+import com.efub.livin.house.dto.request.HouseCreateRequest;
+import com.efub.livin.house.dto.response.HouseResponse;
+import com.efub.livin.house.repository.HouseRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class HouseService {
+
+    private final HouseRepository houseRepository;
+
+    // 새 자취/하숙 정보 등록
+    @Transactional
+    public HouseResponse addHouse(HouseCreateRequest request){
+        House house = House.create(request);
+        House savedHouse = houseRepository.save(house);
+
+        return HouseResponse.from(savedHouse);
+    }
+}

--- a/src/main/java/com/efub/livin/house/service/HouseService.java
+++ b/src/main/java/com/efub/livin/house/service/HouseService.java
@@ -19,7 +19,6 @@ public class HouseService {
 
     private final HouseRepository houseRepository;
     private final KakaoApiClient kakaoApiClient;
-    private final ImageService imageService;
 
     // 새 자취/하숙 정보 등록
     @Transactional

--- a/src/main/java/com/efub/livin/house/service/ImageService.java
+++ b/src/main/java/com/efub/livin/house/service/ImageService.java
@@ -1,0 +1,50 @@
+package com.efub.livin.house.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import java.io.IOException;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class ImageService {
+
+    private final S3Client s3Client;
+
+    @Value("${spring.cloud.aws.s3.bucket}")
+    private String bucket;
+
+    @Value("${spring.cloud.aws.region.static}")
+    private String region;
+
+    public String upload(MultipartFile file, String dirName) throws IOException {
+        if (file == null || file.isEmpty()) return null;
+
+        // 파일명 중복 방지
+        String originalFilename = file.getOriginalFilename();
+        String uniqueFileName = UUID.randomUUID().toString() + "_" + originalFilename;
+        String s3Key = dirName + "/" + uniqueFileName;
+
+        // S3 업로드 요청 객체
+        PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                .bucket(bucket)
+                .key(s3Key)
+                .contentType(file.getContentType())
+                .build();
+
+        // S3 파일 업로드
+        s3Client.putObject(putObjectRequest, RequestBody.fromInputStream(
+                file.getInputStream(), file.getSize()
+        ));
+
+        // S3 Url 반환
+        return "https://" + bucket + ".s3." + region + ".amazonaws.com/" + s3Key;
+    }
+}

--- a/src/main/java/com/efub/livin/house/service/KakaoApiClient.java
+++ b/src/main/java/com/efub/livin/house/service/KakaoApiClient.java
@@ -1,6 +1,9 @@
 package com.efub.livin.house.service;
 
+import com.efub.livin.global.exception.CustomException;
+import com.efub.livin.global.exception.ErrorCode;
 import com.efub.livin.house.dto.response.KakaoResponseDto;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -12,6 +15,7 @@ import org.springframework.web.client.RestTemplate;
 import java.util.HashMap;
 import java.util.Map;
 
+@Slf4j
 @Component
 public class KakaoApiClient {
 
@@ -79,11 +83,15 @@ public class KakaoApiClient {
                     KakaoResponseDto.class,
                     params
             );
+
+            if (response.getBody() == null) {
+                throw new CustomException(ErrorCode.KAKAO_API_EMPTY_RESPONSE);
+            }
             return response.getBody();
 
         } catch (Exception e) {
-            System.err.println("Kakao 주소 검색 API 호출 오류: " + e.getMessage());
-            return null;
+            log.error("Kakao 주소 검색 API 호출 오류: {}", e.getMessage());
+            throw new CustomException(ErrorCode.KAKAO_API_ERROR);
         }
     }
 }

--- a/src/main/java/com/efub/livin/house/service/KakaoApiClient.java
+++ b/src/main/java/com/efub/livin/house/service/KakaoApiClient.java
@@ -31,7 +31,7 @@ public class KakaoApiClient {
         Integer radius = 1500; // 반경. 단위(m). 1.5km
 
         // 카카오 요청 url
-        String url = KEYWORD_API_URL + "?query={keyword}";
+        String url = KEYWORD_API_URL + "?query={keyword}&x={x}&y={y}&radius={radius}&sort=distance";
         Map<String, Object> params = new HashMap<>();
         params.put("keyword", keyword);
         params.put("x", x);

--- a/src/main/java/com/efub/livin/house/service/KakaoApiClient.java
+++ b/src/main/java/com/efub/livin/house/service/KakaoApiClient.java
@@ -1,6 +1,6 @@
 package com.efub.livin.house.service;
 
-import com.efub.livin.house.dto.KakaoResponseDto;
+import com.efub.livin.house.dto.response.KakaoResponseDto;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;

--- a/src/main/java/com/efub/livin/house/service/KakaoApiClient.java
+++ b/src/main/java/com/efub/livin/house/service/KakaoApiClient.java
@@ -1,6 +1,6 @@
 package com.efub.livin.house.service;
 
-import com.efub.livin.house.dto.KakaoResponseDto;
+import com.efub.livin.house.dto.response.KakaoResponseDto;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -15,12 +15,15 @@ import java.util.Map;
 @Component
 public class KakaoApiClient {
 
+    private final RestTemplate restTemplate = new RestTemplate();
+
     @Value("${kakao.map.KAKAO_API_KEY}")
     private String kakaoApiKey;
 
-    @Value("${kakao.map.KAKAO_API_URL}")
-    private String kakaoApiUrl;
+    private static final String KEYWORD_API_URL = "https://dapi.kakao.com/v2/local/search/keyword.json";
+    private static final String ADDRESS_API_URL = "https://dapi.kakao.com/v2/local/search/address.json";
 
+    // 키워드로 장소 검색
     public KakaoResponseDto searchByKeyword(String keyword) {
 
         String x = "126.95"; // 중심 경도
@@ -28,14 +31,12 @@ public class KakaoApiClient {
         Integer radius = 1500; // 반경. 단위(m). 1.5km
 
         // 카카오 요청 url
-        String url = kakaoApiUrl + "?query={keyword}";
+        String url = KEYWORD_API_URL + "?query={keyword}";
         Map<String, Object> params = new HashMap<>();
         params.put("keyword", keyword);
         params.put("x", x);
         params.put("y", y);
         params.put("radius", radius);
-
-        RestTemplate restTemplate = new RestTemplate();
 
         // Header 설정
         HttpHeaders headers = new HttpHeaders();
@@ -53,5 +54,36 @@ public class KakaoApiClient {
         );
 
         return response.getBody();
+    }
+
+
+    // 주소로 좌표 검색
+    public KakaoResponseDto searchAddress(String address) {
+        // 헤더 설정
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "KakaoAK " + kakaoApiKey);
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        // URI 템플릿 설정
+        String url = ADDRESS_API_URL + "?query={query}";
+
+        Map<String, String> params = new HashMap<>();
+        params.put("query", address);
+
+        // API 호출
+        try {
+            ResponseEntity<KakaoResponseDto> response = restTemplate.exchange(
+                    url,
+                    HttpMethod.GET,
+                    entity,
+                    KakaoResponseDto.class,
+                    params
+            );
+            return response.getBody();
+
+        } catch (Exception e) {
+            System.err.println("Kakao 주소 검색 API 호출 오류: " + e.getMessage());
+            return null;
+        }
     }
 }

--- a/src/main/java/com/efub/livin/house/service/KakaoApiClient.java
+++ b/src/main/java/com/efub/livin/house/service/KakaoApiClient.java
@@ -17,7 +17,7 @@ public class KakaoApiClient {
 
     private final RestTemplate restTemplate = new RestTemplate();
 
-    @Value("${kakao.map.KAKAO_API_KEY}")
+    @Value("${kakao.map.kakao-api-key}")
     private String kakaoApiKey;
 
     private static final String KEYWORD_API_URL = "https://dapi.kakao.com/v2/local/search/keyword.json";

--- a/src/main/java/com/efub/livin/house/service/NaverApiClient.java
+++ b/src/main/java/com/efub/livin/house/service/NaverApiClient.java
@@ -17,10 +17,10 @@ public class NaverApiClient {
     private final RestTemplate restTemplate = new RestTemplate();
     private static final String NAVER_API_URL = "https://openapi.naver.com/v1/search/image";
 
-    @Value("${naver.search.NAVER_CLIENT_ID}")
+    @Value("${naver.search.naver-client-id}")
     private String naverClientId;
 
-    @Value("${naver.search.NAVER_CLIENT_SECRET}")
+    @Value("${naver.search.naver-client-secret}")
     private String naverClientSecret;
 
     public NaverImageResponseDto searchImage(String query) {

--- a/src/main/java/com/efub/livin/house/service/NaverApiClient.java
+++ b/src/main/java/com/efub/livin/house/service/NaverApiClient.java
@@ -1,0 +1,56 @@
+package com.efub.livin.house.service;
+
+import com.efub.livin.house.dto.response.NaverImageResponseDto;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.beans.factory.annotation.Value;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+public class NaverApiClient {
+    private final RestTemplate restTemplate = new RestTemplate();
+    private static final String NAVER_API_URL = "https://openapi.naver.com/v1/search/image";
+
+    @Value("${naver.search.NAVER_CLIENT_ID}")
+    private String naverClientId;
+
+    @Value("${naver.search.NAVER_CLIENT_SECRET}")
+    private String naverClientSecret;
+
+    public NaverImageResponseDto searchImage(String query) {
+        // HTTP 헤더
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("X-Naver-Client-Id", naverClientId);
+        headers.set("X-Naver-Client-Secret", naverClientSecret);
+        headers.set("Accept", "application/json"); // JSON 응답 요청
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        // URI 템플릿 설정
+        String url = NAVER_API_URL + "?query={query}&display=1&sort=sim"; // 1개만, 유사도순
+
+        Map<String, String> params = new HashMap<>();
+        params.put("query", query); // 카카오에서 받은 장소 이름
+
+        // API 호출
+        try {
+            ResponseEntity<NaverImageResponseDto> response = restTemplate.exchange(
+                    url,
+                    HttpMethod.GET,
+                    entity,
+                    NaverImageResponseDto.class, // DTO로 자동 변환
+                    params
+            );
+            return response.getBody();
+
+        } catch (Exception e) {
+            System.err.println("Naver API 호출 오류: " + e.getMessage());
+            return null; // 오류 발생 시 null 반환
+        }
+    }
+}

--- a/src/main/java/com/efub/livin/house/service/NaverApiClient.java
+++ b/src/main/java/com/efub/livin/house/service/NaverApiClient.java
@@ -1,6 +1,7 @@
 package com.efub.livin.house.service;
 
 import com.efub.livin.house.dto.response.NaverImageResponseDto;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -12,6 +13,7 @@ import org.springframework.beans.factory.annotation.Value;
 import java.util.HashMap;
 import java.util.Map;
 
+@Slf4j
 @Component
 public class NaverApiClient {
     private final RestTemplate restTemplate = new RestTemplate();
@@ -49,7 +51,8 @@ public class NaverApiClient {
             return response.getBody();
 
         } catch (Exception e) {
-            System.err.println("Naver API 호출 오류: " + e.getMessage());
+            log.error("Naver API 호출 오류 (query: {}): {}. 이미지를 null로 저장합니다.",
+                    query, e.getMessage());
             return null; // 오류 발생 시 null 반환
         }
     }


### PR DESCRIPTION
<!--
name: PR 템플릿
about: PR 생성 시 이 템플릿을 사용해 주세요.
title: "[FEAT]", "[FIX]", ..
-->
## #️⃣ 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요. 
- [x] 새 자취/하숙 데이터 추가 api
- [x] 사용자가 직접 건물 타입, 건물 이름, 주소, 옵션, 주차 가능 여부를 선택해 생성함
- [x] 사용자가 입력한 주소를 map api를 사용해 위도, 경도로 변환해 함께 db에 저장
- [x] 자취/하숙 데이터 Sync시 naver image도 함께 저장
- [x] 새 자취/하숙 데이터 이미지 등록 api
      
## #️⃣ 테스트 내용

> 어떤 테스트를 수행했는지 명시해주세요.  
- [x] Postman 테스트
- [ ] 단위 테스트 수행

## ✅ To-do (선택)
> 작업 예정인 테스크를 작성해주세요.
* house의 price 정보 등록할 방법 찾아보기

## 📎 참고 자료 (선택)

> 관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해주세요.
* 장소 등록
<img width="1063" height="793" alt="image" src="https://github.com/user-attachments/assets/a139d741-6657-4162-8746-635c918b4608" />

* 이미지 등록
<img width="1057" height="623" alt="image" src="https://github.com/user-attachments/assets/f9b14b58-b79f-4695-89d3-f4c30cc0b8ae" />


## 📌 연관 이슈

> #이슈번호 
* #7 
* #4 
