### PR TITLE
[FEAT] 자취/하숙 검색 및 필터링 기능

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,10 @@ repositories {
 	mavenCentral()
 }
 
+ext {
+	querydslVersion = "5.0.0"
+}
+
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
@@ -36,6 +40,11 @@ dependencies {
 	// s3
 	implementation platform("io.awspring.cloud:spring-cloud-aws-dependencies:3.0.1")
 	implementation "io.awspring.cloud:spring-cloud-aws-starter-s3"
+	// queryDsl
+	implementation "com.querydsl:querydsl-jpa:${querydslVersion}:jakarta"
+	annotationProcessor "com.querydsl:querydsl-apt:${querydslVersion}:jakarta"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
 }
 
 tasks.named('test') {

--- a/src/main/java/com/efub/livin/global/config/QueryDslConfig.java
+++ b/src/main/java/com/efub/livin/global/config/QueryDslConfig.java
@@ -1,0 +1,19 @@
+package com.efub.livin.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class QueryDslConfig {
+
+    private final EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/efub/livin/house/controller/HouseController.java
+++ b/src/main/java/com/efub/livin/house/controller/HouseController.java
@@ -1,18 +1,14 @@
 package com.efub.livin.house.controller;
 
-import com.efub.livin.house.domain.House;
 import com.efub.livin.house.dto.request.HouseCreateRequest;
+import com.efub.livin.house.dto.response.HousePagingListResponse;
 import com.efub.livin.house.dto.response.HouseResponse;
 import com.efub.livin.house.service.HouseService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
-
-import java.io.IOException;
 
 @RestController
 @RequiredArgsConstructor
@@ -28,5 +24,19 @@ public class HouseController {
 
         HouseResponse response = houseService.addHouse(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    // 자취/하숙 검색 및 필터링 컨트롤러
+    // GET /house/search?keyword=신촌&sort=Popular&type=PRIVATE&address=서대문구&page=0
+    @GetMapping(value = "/search")
+    public ResponseEntity<HousePagingListResponse> search(
+            @RequestParam(value = "keyword", required = false) String keyword,
+            @RequestParam(value = "sort") String sort,
+            @RequestParam(value = "type") String type,
+            @RequestParam(value = "address") String address,
+            @RequestParam(value = "page") int page
+    ) {
+        HousePagingListResponse response = houseService.search(keyword, sort, type, address, page);
+        return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 }

--- a/src/main/java/com/efub/livin/house/domain/House.java
+++ b/src/main/java/com/efub/livin/house/domain/House.java
@@ -4,6 +4,7 @@ import com.efub.livin.house.dto.request.HouseCreateRequest;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
+import org.hibernate.annotations.ColumnDefault;
 
 @Entity
 @Getter @Setter
@@ -34,7 +35,12 @@ public class House {
     private HouseType type; // 자취방 PRIVATE, 하숙 BOARDING
 
     // 리뷰 관련
-    private float rate;
+    @ColumnDefault("0")
+    private float rate = 0;
+
+    // 북마크 개수
+    @ColumnDefault("0")
+    private int bookmarkCnt = 0;
 
     // 리뷰 관계 코드
 

--- a/src/main/java/com/efub/livin/house/dto/response/HousePagingListResponse.java
+++ b/src/main/java/com/efub/livin/house/dto/response/HousePagingListResponse.java
@@ -1,0 +1,23 @@
+package com.efub.livin.house.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class HousePagingListResponse {
+    private List<HouseResponse> houses;
+    private int totalPages;
+    private int currentPage;
+    private int length;
+
+    public HousePagingListResponse(Page<HouseResponse> page){
+        this.houses = page.getContent();
+        this.totalPages = page.getTotalPages();
+        this.currentPage = page.getNumber();
+        this.length = page.getNumberOfElements();
+    }
+}

--- a/src/main/java/com/efub/livin/house/repository/CustomHouseRepository.java
+++ b/src/main/java/com/efub/livin/house/repository/CustomHouseRepository.java
@@ -1,0 +1,9 @@
+package com.efub.livin.house.repository;
+
+import com.efub.livin.house.domain.House;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface CustomHouseRepository {
+    Page<House> search(String keyword, String sort, String type, String address, Pageable pageable);
+}

--- a/src/main/java/com/efub/livin/house/repository/CustomHouseRepositoryImpl.java
+++ b/src/main/java/com/efub/livin/house/repository/CustomHouseRepositoryImpl.java
@@ -1,0 +1,92 @@
+package com.efub.livin.house.repository;
+
+import com.efub.livin.house.domain.House;
+import com.efub.livin.house.domain.HouseType;
+import com.efub.livin.house.domain.QHouse;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+public class CustomHouseRepositoryImpl implements CustomHouseRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<House> search(
+            String keyword, // null 가능
+            String sort,    // review(default), bookmark
+            String type,    // all(default), private, boarding
+            String address, // all(default), 서대문구, 마포구...
+            Pageable pageable) {
+        QHouse house = QHouse.house;
+
+        BooleanBuilder builder = new BooleanBuilder();
+
+        // keyword 검색
+        if (hasText(keyword)) {
+            builder.and(house.buildingName.contains(keyword));
+        }
+        // 전체/자취/하숙 필터링
+        HouseType houseType = parseHouseType(type);
+        if(houseType != null){
+            builder.and(house.type.eq(houseType));
+        }
+        // 자치구 필터링
+        if (hasText(address) && !address.equalsIgnoreCase("all")) {
+            builder.and(house.address.contains(address));
+        }
+        // 정렬 (review/bookmark)
+        OrderSpecifier<?> sortOrder;
+        if(sort != null && sort.equalsIgnoreCase("bookmark")){
+            sortOrder = house.bookmarkCnt.desc();
+        } else {
+            sortOrder = house.rate.desc();
+        }
+
+        List<House> content = queryFactory
+                .selectFrom(house)
+                .where(builder)
+                .orderBy(sortOrder)
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        // 전체 목록 개수
+        Long total = queryFactory
+                .select(house.count())
+                .from(house)
+                .where(builder)
+                .fetchOne();
+
+        long totalCount = (total != null) ? total : 0L;
+
+        return new PageImpl<>(content, pageable, totalCount);
+    }
+
+    private HouseType parseHouseType(String type) {
+        if (type == null || type.equalsIgnoreCase("all")) {
+            return null; // 전체 조회
+        }
+
+        if (type.equalsIgnoreCase("private")) {
+            return HouseType.PRIVATE;
+        }
+
+        if (type.equalsIgnoreCase("boarding")) {
+            return HouseType.BOARDING;
+        }
+
+        return null;
+    }
+
+    private boolean hasText(String value) {
+        return value != null && !value.trim().isEmpty();
+    }
+}

--- a/src/main/java/com/efub/livin/house/repository/HouseRepository.java
+++ b/src/main/java/com/efub/livin/house/repository/HouseRepository.java
@@ -3,5 +3,5 @@ package com.efub.livin.house.repository;
 import com.efub.livin.house.domain.House;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface HouseRepository extends JpaRepository<House, Long> {
+public interface HouseRepository extends JpaRepository<House, Long>, CustomHouseRepository {
 }

--- a/src/main/java/com/efub/livin/house/service/HouseService.java
+++ b/src/main/java/com/efub/livin/house/service/HouseService.java
@@ -2,16 +2,16 @@ package com.efub.livin.house.service;
 
 import com.efub.livin.house.domain.Document;
 import com.efub.livin.house.domain.House;
-import com.efub.livin.house.dto.response.KakaoResponseDto;
+import com.efub.livin.house.dto.response.HousePagingListResponse;
 import com.efub.livin.house.dto.request.HouseCreateRequest;
 import com.efub.livin.house.dto.response.HouseResponse;
 import com.efub.livin.house.repository.HouseRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
-
-import java.io.IOException;
 
 @Service
 @RequiredArgsConstructor
@@ -19,6 +19,8 @@ public class HouseService {
 
     private final HouseRepository houseRepository;
     private final KakaoApiClient kakaoApiClient;
+
+    private static final int house_list_size = 20;  // 임시로 20개 설정. 추후 프론트와 연동해보며 조절 예정
 
     // 새 자취/하숙 정보 등록
     @Transactional
@@ -32,5 +34,20 @@ public class HouseService {
         House savedHouse = houseRepository.save(house);
 
         return HouseResponse.from(savedHouse);
+    }
+
+    // 자취/하숙 검색 및 필터링
+    @Transactional(readOnly = true)
+    public HousePagingListResponse search(
+            String keyword, // null 가능
+            String sort,    // review(default), bookmark
+            String type,    // all(default), private, boarding
+            String address, // all(default), 서대문구, 마포구, 종로구, 중구, 은평구, 용산구
+            int page) {
+        Pageable pageable = PageRequest.of(page, house_list_size);
+        Page<House> searchHouses = houseRepository.search(keyword, sort, type, address, pageable);
+
+        Page<HouseResponse> dtoPage = searchHouses.map(HouseResponse::from);
+        return new HousePagingListResponse(dtoPage);
     }
 }


### PR DESCRIPTION
## #️⃣ 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요. 
- [x] 자취/하숙 검색 및 필터링
    - keyword 검색
    - 리뷰별점/북마크 순 정렬
    - 자취/하숙/전체 필터링
    - 서대문구/마포구/전체 필터링
    - 페이징
      
## #️⃣ 테스트 내용
> 어떤 테스트를 수행했는지 명시해주세요.  
- [x] Postman 테스트
- [ ] 단위 테스트 수행

## ✅ To-do (선택)
> 작업 예정인 테스크를 작성해주세요.

현재 지도 기준 보여질 집 리스트들을 구현할 예정입니다.

## 📎 참고 사항 (선택)
- 필터링 해야할 게 많아서, 이걸 jpa로만 구현하기에는... repository에 긴긴이름으로 만들어야할 함수들이 8개나 되어서 가독성이 너무 떨어지는 바람에.. 😅 queryDsl로 구현했습니다! 다들 gradle clean 하는 세팅 한 번씩 부탁드립니다!! 

## 📌 연관 이슈
closes #6 
