### PR TITLE
[Feat] 자취/하숙 상세 페이지 조회 api 구현

### DIFF
--- a/src/main/java/com/efub/livin/global/s3/S3Service.java
+++ b/src/main/java/com/efub/livin/global/s3/S3Service.java
@@ -1,4 +1,4 @@
-package com.efub.livin.house.service;
+package com.efub.livin.global.s3;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -6,7 +6,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 import java.io.IOException;
@@ -14,7 +13,7 @@ import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
-public class ImageService {
+public class S3Service {
 
     private final S3Client s3Client;
 

--- a/src/main/java/com/efub/livin/house/controller/HouseController.java
+++ b/src/main/java/com/efub/livin/house/controller/HouseController.java
@@ -26,6 +26,13 @@ public class HouseController {
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
+    // 자취/하숙 상세 조회 컨트롤러
+    @GetMapping(value = "/{houseId}")
+    public ResponseEntity<HouseResponse> getOneHouse(@PathVariable Long houseId) {
+        HouseResponse response = houseService.getHouse(houseId);
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
     // 자취/하숙 검색 및 필터링 컨트롤러
     // GET /house/search?keyword=신촌&sort=Popular&type=PRIVATE&address=서대문구&page=0
     @GetMapping(value = "/search")

--- a/src/main/java/com/efub/livin/house/controller/HouseSaveController.java
+++ b/src/main/java/com/efub/livin/house/controller/HouseSaveController.java
@@ -1,6 +1,6 @@
 package com.efub.livin.house.controller;
 
-import com.efub.livin.house.service.HouseSaveService;
+import com.efub.livin.house.service.HouseSyncService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/kakao")
 public class HouseSaveController {
 
-    private final HouseSaveService houseSaveService;
+    private final HouseSyncService houseSaveService;
 
     @PostMapping(value = "/sync")
     public ResponseEntity<String> syncAndSave() {

--- a/src/main/java/com/efub/livin/house/controller/ImageController.java
+++ b/src/main/java/com/efub/livin/house/controller/ImageController.java
@@ -1,6 +1,6 @@
 package com.efub.livin.house.controller;
 
-import com.efub.livin.house.service.ImageService;
+import com.efub.livin.global.s3.S3Service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -17,7 +17,7 @@ import java.io.IOException;
 @RequestMapping("/house/image")
 public class ImageController {
 
-    private final ImageService imageService;
+    private final S3Service imageService;
 
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<String> uploadImage(@RequestParam("image") MultipartFile file) throws IOException {

--- a/src/main/java/com/efub/livin/house/domain/House.java
+++ b/src/main/java/com/efub/livin/house/domain/House.java
@@ -1,10 +1,14 @@
 package com.efub.livin.house.domain;
 
 import com.efub.livin.house.dto.request.HouseCreateRequest;
+import com.efub.livin.review.domain.HouseReview;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.annotations.ColumnDefault;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter @Setter
@@ -43,6 +47,8 @@ public class House {
     private int bookmarkCnt = 0;
 
     // 리뷰 관계 코드
+    @OneToMany(mappedBy = "house", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<HouseReview> reviews = new ArrayList<>();
 
     // Document dto -> House 엔티티로 변환
     public static House from(Document dto, HouseType type, String imageUrl){

--- a/src/main/java/com/efub/livin/house/service/HouseService.java
+++ b/src/main/java/com/efub/livin/house/service/HouseService.java
@@ -36,6 +36,12 @@ public class HouseService {
         return HouseResponse.from(savedHouse);
     }
 
+    // 자취/하숙 상세 정보 조회
+    @Transactional(readOnly = true)
+    public HouseResponse getHouse(Long id) {
+        return houseRepository.findById(id).map(HouseResponse::from).orElse(null);
+    }
+
     // 자취/하숙 검색 및 필터링
     @Transactional(readOnly = true)
     public HousePagingListResponse search(

--- a/src/main/java/com/efub/livin/house/service/HouseSyncService.java
+++ b/src/main/java/com/efub/livin/house/service/HouseSyncService.java
@@ -15,7 +15,7 @@ import static com.efub.livin.house.domain.HouseType.PRIVATE;
 
 @Service
 @RequiredArgsConstructor
-public class HouseSaveService {
+public class HouseSyncService {
 
     private final KakaoApiClient kakaoApiClient;
     private final NaverApiClient naverApiClient;


### PR DESCRIPTION
<!--
name: PR 템플릿
about: PR 생성 시 이 템플릿을 사용해 주세요.
title: "[FEAT]", "[FIX]", ..
-->
## #️⃣ 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요. 
- [x] 자취/하숙 상세 페이지 조회 api 구현
- [x] `ImageService.java` -> `S3Service.java`로 파일명 변경
- [x] `S3Service.java` global 폴더로 이동
- [x] `HouseSaveService.java` -> `HouseSyncService.java`로 파일명 변경(자취/하숙 데이터 불러오기)
- [x] House에 HouseReview 필드 추가
      
## #️⃣ 테스트 내용

> 어떤 테스트를 수행했는지 명시해주세요.  
- [x] Postman 테스트
- [ ] 단위 테스트 수행

## ✅ To-do (선택)
> 데이터를 외부 api에서 불러온 경우 parking이랑 options 등의 필드가 비어있어서 review의 내용 중 가장 많은 비율인 것으로 반환할 지 고민 중입니다.

## 📎 참고 자료 (선택)

> 관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해주세요.
<img width="1072" height="642" alt="image" src="https://github.com/user-attachments/assets/55ef5f25-8b49-4366-9366-bb8c10e1c3e8" />


## 📌 연관 이슈
* #16 
