### PR TITLE
[FEAT] 카카오맵 api 사용하여 편의시설 및 자취/하숙 리스트 조회

### DIFF
--- a/src/main/java/com/efub/livin/house/controller/HouseController.java
+++ b/src/main/java/com/efub/livin/house/controller/HouseController.java
@@ -3,6 +3,7 @@ package com.efub.livin.house.controller;
 import com.efub.livin.house.dto.request.HouseCreateRequest;
 import com.efub.livin.house.dto.response.HousePagingListResponse;
 import com.efub.livin.house.dto.response.HouseResponse;
+import com.efub.livin.house.dto.response.MapDataResponse;
 import com.efub.livin.house.service.HouseService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -38,5 +39,32 @@ public class HouseController {
     ) {
         HousePagingListResponse response = houseService.search(keyword, sort, type, address, page);
         return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+    // 지도 위에 띄울 자취/하숙 정보 및 편의시설 정보 조회 컨트롤러
+     /** GET /house/map?minLat=1127385&maxLat=1128001.25&minLon=487431.875&maxLon=488315.625
+     * &centerLat=1127693.125&centerLon=487873.75&radius=538.697
+     * &showCafe=true&showFood=true
+     */
+    @GetMapping("/map")
+    public MapDataResponse getMap(
+            @RequestParam(value = "minLat") double minLat,
+            @RequestParam(value = "maxLat") double maxLat,
+            @RequestParam(value = "minLon") double minLon,
+            @RequestParam(value = "maxLon") double maxLon,
+            @RequestParam(value = "centerLat") double centerLat,
+            @RequestParam(value = "centerLon") double centerLon,
+            @RequestParam(value = "radius") double radius,
+            @RequestParam(value = "houseType", defaultValue = "ALL") String houseType,
+            @RequestParam(value = "showCafe", defaultValue = "false") boolean showCafe,
+            @RequestParam(value = "showStore", defaultValue = "false") boolean showStore,
+            @RequestParam(value = "showFood", defaultValue = "false") boolean showFood,
+            @RequestParam(value = "showTransport", defaultValue = "false") boolean showTransport
+    ) {
+        return houseService.getMapWithPoiData(
+                minLat, maxLat, minLon, maxLon,
+                centerLat, centerLon, radius,
+                houseType, showCafe, showStore, showFood, showTransport
+        );
     }
 }

--- a/src/main/java/com/efub/livin/house/dto/response/HouseMapResponse.java
+++ b/src/main/java/com/efub/livin/house/dto/response/HouseMapResponse.java
@@ -1,0 +1,33 @@
+package com.efub.livin.house.dto.response;
+
+import com.efub.livin.house.domain.House;
+import com.efub.livin.house.domain.HouseType;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class HouseMapResponse {
+    private Long houseId;
+    private String buildingName;
+    private String address;
+    private String category;
+    private HouseType type;
+    private String x; // 경도
+    private String y; // 위도
+
+    public static HouseMapResponse from (House house) {
+        return HouseMapResponse.builder()
+                .houseId(house.getHouseId())
+                .buildingName(house.getBuildingName())
+                .address(house.getAddress())
+                .category("house")
+                .type(house.getType())
+                .x(house.getLon())  // 경도
+                .y(house.getLat())  // 위도
+                .build();
+    }
+}

--- a/src/main/java/com/efub/livin/house/dto/response/MapDataResponse.java
+++ b/src/main/java/com/efub/livin/house/dto/response/MapDataResponse.java
@@ -1,0 +1,19 @@
+package com.efub.livin.house.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class MapDataResponse {
+    private List<HouseMapResponse> houses;   // 자취/하숙
+    private List<PoiResponse> cafes;         // 카페
+    private List<PoiResponse> stores;        // 편의점/마트
+    private List<PoiResponse> restaurants;   // 식당
+    private List<PoiResponse> transports;    // 교통(지하철)
+}

--- a/src/main/java/com/efub/livin/house/dto/response/PoiResponse.java
+++ b/src/main/java/com/efub/livin/house/dto/response/PoiResponse.java
@@ -1,0 +1,14 @@
+package com.efub.livin.house.dto.response;
+
+import lombok.*;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class PoiResponse {
+    private String placeName;
+    private String address;
+    private String category;
+    private Double x; // 경도
+    private Double y; // 위도
+}

--- a/src/main/java/com/efub/livin/house/repository/CustomHouseRepository.java
+++ b/src/main/java/com/efub/livin/house/repository/CustomHouseRepository.java
@@ -9,7 +9,7 @@ import java.util.List;
 
 public interface CustomHouseRepository {
     // 검색어 기반 자취/하숙 필터링
-    Page<House> search(String keyword, String sort, String type, String address, Pageable pageable);
+    Page<House> search(String keyword, String sort, HouseType houseType, String address, Pageable pageable);
 
     // 지도 중심 범위 기준 자취/하숙 리스트
     List<House> findInBounds(double minLat, double maxLat, double minLon, double maxLon, HouseType houseType);

--- a/src/main/java/com/efub/livin/house/repository/CustomHouseRepository.java
+++ b/src/main/java/com/efub/livin/house/repository/CustomHouseRepository.java
@@ -1,9 +1,16 @@
 package com.efub.livin.house.repository;
 
 import com.efub.livin.house.domain.House;
+import com.efub.livin.house.domain.HouseType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
+
 public interface CustomHouseRepository {
+    // 검색어 기반 자취/하숙 필터링
     Page<House> search(String keyword, String sort, String type, String address, Pageable pageable);
+
+    // 지도 중심 범위 기준 자취/하숙 리스트
+    List<House> findInBounds(double minLat, double maxLat, double minLon, double maxLon, HouseType houseType);
 }

--- a/src/main/java/com/efub/livin/house/repository/CustomHouseRepositoryImpl.java
+++ b/src/main/java/com/efub/livin/house/repository/CustomHouseRepositoryImpl.java
@@ -70,6 +70,26 @@ public class CustomHouseRepositoryImpl implements CustomHouseRepository {
         return new PageImpl<>(content, pageable, totalCount);
     }
 
+    @Override
+    public List<House> findInBounds(double minLat, double maxLat, double minLon, double maxLon,
+                                    HouseType houseType) {
+        QHouse house = QHouse.house;
+
+        BooleanBuilder builder = new BooleanBuilder()
+                .and(house.lat.castToNum(Double.class).between(minLat, maxLat))
+                .and(house.lon.castToNum(Double.class).between(minLon, maxLon));
+
+        // 자취/하숙/전체
+        if(houseType != null){
+            builder.and(house.type.eq(houseType));
+        }
+
+        return queryFactory
+                .selectFrom(house)
+                .where(builder)
+                .fetch();
+    }
+
     private HouseType parseHouseType(String type) {
         if (type == null || type.equalsIgnoreCase("all")) {
             return null; // 전체 조회

--- a/src/main/java/com/efub/livin/house/repository/CustomHouseRepositoryImpl.java
+++ b/src/main/java/com/efub/livin/house/repository/CustomHouseRepositoryImpl.java
@@ -22,7 +22,7 @@ public class CustomHouseRepositoryImpl implements CustomHouseRepository {
     public Page<House> search(
             String keyword, // null 가능
             String sort,    // review(default), bookmark
-            String type,    // all(default), private, boarding
+            HouseType houseType,
             String address, // all(default), 서대문구, 마포구...
             Pageable pageable) {
         QHouse house = QHouse.house;
@@ -34,7 +34,6 @@ public class CustomHouseRepositoryImpl implements CustomHouseRepository {
             builder.and(house.buildingName.contains(keyword));
         }
         // 전체/자취/하숙 필터링
-        HouseType houseType = parseHouseType(type);
         if(houseType != null){
             builder.and(house.type.eq(houseType));
         }
@@ -88,22 +87,6 @@ public class CustomHouseRepositoryImpl implements CustomHouseRepository {
                 .selectFrom(house)
                 .where(builder)
                 .fetch();
-    }
-
-    private HouseType parseHouseType(String type) {
-        if (type == null || type.equalsIgnoreCase("all")) {
-            return null; // 전체 조회
-        }
-
-        if (type.equalsIgnoreCase("private")) {
-            return HouseType.PRIVATE;
-        }
-
-        if (type.equalsIgnoreCase("boarding")) {
-            return HouseType.BOARDING;
-        }
-
-        return null;
     }
 
     private boolean hasText(String value) {

--- a/src/main/java/com/efub/livin/house/service/HouseService.java
+++ b/src/main/java/com/efub/livin/house/service/HouseService.java
@@ -78,16 +78,16 @@ public class HouseService {
 
         int radius = (int) Math.ceil(doubleRadius);
         if (isShowCafe) {
-            cafes = mapService.getCafes(centerLat, centerLon, radius);
+            cafes = mapService.getCafes(centerLon, centerLat, radius);
         }
         if (isShowStore) {
-            stores = mapService.getStores(centerLat, centerLon, radius);
+            stores = mapService.getStores(centerLon, centerLat, radius);
         }
         if (isShowFood) {
-            foods = mapService.getFoods(centerLat, centerLon, radius);
+            foods = mapService.getFoods(centerLon, centerLat, radius);
         }
         if (isShowTransport) {
-            transports = mapService.getTransports(centerLat, centerLon, radius);
+            transports = mapService.getTransports(centerLon, centerLat, radius);
         }
 
         return MapDataResponse.builder()

--- a/src/main/java/com/efub/livin/house/service/HouseService.java
+++ b/src/main/java/com/efub/livin/house/service/HouseService.java
@@ -47,9 +47,11 @@ public class HouseService {
             String sort,    // review(default), bookmark
             String type,    // all(default), private, boarding
             String address, // all(default), 서대문구, 마포구, 종로구, 중구, 은평구, 용산구
-            int page) {
+            int page
+    ) {
         Pageable pageable = PageRequest.of(page, house_list_size);
-        Page<House> searchHouses = houseRepository.search(keyword, sort, type, address, pageable);
+        HouseType houseType = parseHouseType(type);
+        Page<House> searchHouses = houseRepository.search(keyword, sort, houseType, address, pageable);
 
         Page<HouseResponse> dtoPage = searchHouses.map(HouseResponse::from);
         return new HousePagingListResponse(dtoPage);
@@ -63,9 +65,7 @@ public class HouseService {
             String type, boolean isShowCafe, boolean isShowStore, boolean isShowFood, boolean isShowTransport
     ) {
         // houseType 파싱
-        HouseType houseType = null; // ALL이면 null
-        if (type.equalsIgnoreCase("private")) houseType = HouseType.PRIVATE;
-        if (type.equalsIgnoreCase("boarding")) houseType = HouseType.BOARDING;
+        HouseType houseType = parseHouseType(type);
 
         // 자취/하숙 조회
         List<HouseMapResponse> houses = mapService.getHousesInBounds(minLat, maxLat, minLon, maxLon, houseType);
@@ -97,5 +97,24 @@ public class HouseService {
                 .restaurants(foods)
                 .transports(transports)
                 .build();
+    }
+
+    /**
+     * HouseType String -> enum으로 파싱
+     * */
+    private HouseType parseHouseType(String type) {
+        if (type == null || type.equalsIgnoreCase("all")) {
+            return null; // 전체 조회
+        }
+
+        if (type.equalsIgnoreCase("private")) {
+            return HouseType.PRIVATE;
+        }
+
+        if (type.equalsIgnoreCase("boarding")) {
+            return HouseType.BOARDING;
+        }
+
+        return null;
     }
 }

--- a/src/main/java/com/efub/livin/house/service/HouseService.java
+++ b/src/main/java/com/efub/livin/house/service/HouseService.java
@@ -73,7 +73,7 @@ public class HouseService {
         // 편의시설 조회 (토글에 따라 선택적으로)
         List<PoiResponse> cafes = List.of();
         List<PoiResponse> stores = List.of();
-        List<PoiResponse> restaurants = List.of();
+        List<PoiResponse> foods = List.of();
         List<PoiResponse> transports = List.of();
 
         int radius = (int) Math.ceil(doubleRadius);
@@ -84,17 +84,17 @@ public class HouseService {
             stores = mapService.getStores(centerLat, centerLon, radius);
         }
         if (isShowFood) {
-            stores = mapService.getFoods(centerLat, centerLon, radius);
+            foods = mapService.getFoods(centerLat, centerLon, radius);
         }
         if (isShowTransport) {
-            stores = mapService.getTransports(centerLat, centerLon, radius);
+            transports = mapService.getTransports(centerLat, centerLon, radius);
         }
 
         return MapDataResponse.builder()
                 .houses(houses)
                 .cafes(cafes)
                 .stores(stores)
-                .restaurants(restaurants)
+                .restaurants(foods)
                 .transports(transports)
                 .build();
     }

--- a/src/main/java/com/efub/livin/house/service/MapService.java
+++ b/src/main/java/com/efub/livin/house/service/MapService.java
@@ -9,6 +9,7 @@ import com.efub.livin.house.repository.HouseRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -28,12 +29,13 @@ public class MapService {
     public List<PoiResponse> getStores(double centerX, double centerY, int radius) {
         // 편의점
         KakaoResponseDto storeDto = kakaoApiClient.searchPoiByCategory("CS2", centerX, centerY, radius);
-        List<PoiResponse> store = toPoiResponses(storeDto, "store");
-
         // 대형마트
         KakaoResponseDto martDto = kakaoApiClient.searchPoiByCategory("MT1", centerX, centerY, radius);
-        //TODO: test로 category 우선 mart로 지정. 추후 store로 변경 필요
-        store.addAll(toPoiResponses(martDto, "mart"));
+
+        List<PoiResponse> store = new ArrayList<>();
+
+        store.addAll(toPoiResponses(storeDto, "store"));
+        store.addAll(toPoiResponses(martDto, "store"));
 
         return store;
     }

--- a/src/main/java/com/efub/livin/house/service/MapService.java
+++ b/src/main/java/com/efub/livin/house/service/MapService.java
@@ -1,0 +1,78 @@
+package com.efub.livin.house.service;
+
+import com.efub.livin.house.domain.House;
+import com.efub.livin.house.domain.HouseType;
+import com.efub.livin.house.dto.response.HouseMapResponse;
+import com.efub.livin.house.dto.response.KakaoResponseDto;
+import com.efub.livin.house.dto.response.PoiResponse;
+import com.efub.livin.house.repository.HouseRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class MapService {
+
+    private final KakaoApiClient kakaoApiClient;
+    private final HouseRepository houseRepository;
+
+    // 카페
+    public List<PoiResponse> getCafes(double centerX, double centerY, int radius) {
+        KakaoResponseDto dto = kakaoApiClient.searchPoiByCategory("CE7", centerX, centerY, radius);
+        return toPoiResponses(dto, "cafe");
+    }
+
+    // 마트 (편의점 & 대형마트)
+    public List<PoiResponse> getStores(double centerX, double centerY, int radius) {
+        // 편의점
+        KakaoResponseDto storeDto = kakaoApiClient.searchPoiByCategory("CS2", centerX, centerY, radius);
+        List<PoiResponse> store = toPoiResponses(storeDto, "store");
+
+        // 대형마트
+        KakaoResponseDto martDto = kakaoApiClient.searchPoiByCategory("MT1", centerX, centerY, radius);
+        //TODO: test로 category 우선 mart로 지정. 추후 store로 변경 필요
+        store.addAll(toPoiResponses(martDto, "mart"));
+
+        return store;
+    }
+
+    // 식당
+    public List<PoiResponse> getFoods(double centerX, double centerY, int radius) {
+        KakaoResponseDto dto = kakaoApiClient.searchPoiByCategory("FD6", centerX, centerY, radius);
+        return toPoiResponses(dto, "food");
+    }
+
+    // 교통 (지하철)
+    // TODO: 버스정류장 저장. kakao에서 제공하는 category에는 버스정류장은 따로 없어서, 검색어 입력으로 받아와야할 듯.
+    public List<PoiResponse> getTransports(double centerX, double centerY, int radius) {
+        // 지하철
+        KakaoResponseDto dto = kakaoApiClient.searchPoiByCategory("SW8", centerX, centerY, radius);
+        return toPoiResponses(dto, "transport");
+    }
+
+    // 지도에 보일 자취/하숙 정보 불러오기
+    public List<HouseMapResponse> getHousesInBounds(
+            double minLat, double maxLat,
+            double minLon, double maxLon,
+            HouseType typeOrNull // null이면 ALL
+    ) {
+        List<House> result = houseRepository.findInBounds(minLat, maxLat, minLon, maxLon, typeOrNull);
+        return result.stream()
+                .map(HouseMapResponse::from)
+                .toList();
+    }
+
+    private List<PoiResponse> toPoiResponses(KakaoResponseDto dto, String category) {
+        return dto.getDocuments().stream()
+                .map(doc -> PoiResponse.builder()
+                        .placeName(doc.getPlace_name())
+                        .y(Double.parseDouble(doc.getY()))
+                        .x(Double.parseDouble(doc.getX()))
+                        .address(doc.getAddress_name())
+                        .category(category)
+                        .build())
+                .toList();
+    }
+}


### PR DESCRIPTION
## #️⃣ 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요. 
- [x] 카카오맵으로 카테고리별 편의시설 조회
- [x] 지도에서 보여지는 범위를 기준으로 자취/하숙 리스트 조회
      
## #️⃣ 테스트 내용
> 어떤 테스트를 수행했는지 명시해주세요.  
- [x] Postman 테스트
- [ ] 단위 테스트 수행

## 📎 참고 자료 (선택)
> 관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해주세요.

[https://developers.kakao.com/docs/latest/ko/local/dev-guide#search-by-category](https://developers.kakao.com/docs/latest/ko/local/dev-guide#search-by-category)
이거 참고해서 카테고리별 조회 작성했습니다.
교통의 경우 제공하는 값이 지하철밖에 없어서, 논의해보고 버스정류장이 필요하다면 카테고리별이 아닌 검색어 기반으로 조회하는걸 추가 해보도록 하겠습니다.

프론트에서 넘겨줘야하는 위도경도 정보값이 너무 많아서, 추후에 리팩토링 진행해보도록 하겠습니다.

## 📌 연관 이슈
- closes #15 
