### PR TITLE
[FEAT] 자취/하숙 데이터 Sync 시 상세 정보 받아오기 및 House 필드 추가

### DIFF
--- a/src/main/java/com/efub/livin/global/exception/ErrorCode.java
+++ b/src/main/java/com/efub/livin/global/exception/ErrorCode.java
@@ -2,6 +2,7 @@ package com.efub.livin.global.exception;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import org.springframework.http.HttpStatus;
 
 @Getter
 @AllArgsConstructor
@@ -21,6 +22,9 @@ public enum ErrorCode {
     KAKAO_API_ERROR(500, "카카오 API 연동 중 오류가 발생했습니다."),
     KAKAO_API_EMPTY_RESPONSE(500, "카카오 API로부터 빈 응답을 받았습니다."),
     HOUSE_NOT_FOUND(404, "해당 하숙/자취 건물을 찾을 수 없습니다."),
+    FILE_NOT_FOUND(500, "지정된 경로에서 CSV 파일을 찾을 수 없습니다."),
+    FILE_READ_ERROR(500, "CSV 파일을 읽는 도중 오류가 발생했습니다."),
+    DATA_PARSING_ERROR(500, "데이터 파싱 중 오류가 발생했습니다."),
 
     //리뷰 관련
     HOUSE_REVIEW_NOT_FOUND(404, "해당 자취/하숙 리뷰를 찾을 수 없습니다."),

--- a/src/main/java/com/efub/livin/house/controller/HouseController.java
+++ b/src/main/java/com/efub/livin/house/controller/HouseController.java
@@ -26,9 +26,10 @@ public class HouseController {
     // 새 자취/하숙 생성 컨트롤러
     @PostMapping(value = "/new")
     public ResponseEntity<HouseResponse> save(
-            @Valid @RequestBody HouseCreateRequest request) {
+            @Valid @RequestBody HouseCreateRequest request,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
 
-        HouseResponse response = houseService.addHouse(request);
+        HouseResponse response = houseService.addHouse(request, userDetails.getUser());
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 

--- a/src/main/java/com/efub/livin/house/controller/HouseSyncController.java
+++ b/src/main/java/com/efub/livin/house/controller/HouseSyncController.java
@@ -1,5 +1,6 @@
 package com.efub.livin.house.controller;
 
+import com.efub.livin.house.service.HouseDetailService;
 import com.efub.livin.house.service.HouseSyncService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -13,11 +14,13 @@ import org.springframework.web.bind.annotation.*;
 public class HouseSyncController {
 
     private final HouseSyncService houseSaveService;
+    private final HouseDetailService houseDetailService;
 
     @PostMapping(value = "/sync")
     public ResponseEntity<String> syncAndSave() {
         try {
             houseSaveService.syncAndSave();
+            houseDetailService.updateDetailsFromCsv();
             return ResponseEntity.ok("데이터 동기화 작업 성공");
 
         } catch (Exception e) {

--- a/src/main/java/com/efub/livin/house/domain/House.java
+++ b/src/main/java/com/efub/livin/house/domain/House.java
@@ -24,13 +24,17 @@ public class House extends BaseEntity {
     private Long houseId;
 
     private String buildingName;
-    private String address;
+
+    @Column(unique = true)
+    private String address; // 중복된 건물이 없도록
+
     private String phone; // 대표 번호
     private String lon; // 경도
     private String lat; // 위도
     private String place_url; // 상세 페이지 URL
     private String docId; // 지도 자체 장소 id
     private Integer floor;
+    private Boolean elevator; // 엘베
     private Boolean parking;
     private String options;
 
@@ -53,6 +57,13 @@ public class House extends BaseEntity {
     // 리뷰 관계 코드
     @OneToMany(mappedBy = "house", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<HouseReview> reviews = new ArrayList<>();
+
+    // csv 데이터로 필드 업데이트
+    public void updateSystemInfo(int floor, boolean elevator, boolean parking) {
+        this.floor = floor;
+        this.elevator = elevator;
+        this.parking = parking;
+    }
 
     // Document dto -> House 엔티티로 변환
     public static House from(Document dto, HouseType type, String imageUrl){

--- a/src/main/java/com/efub/livin/house/domain/House.java
+++ b/src/main/java/com/efub/livin/house/domain/House.java
@@ -4,10 +4,7 @@ import com.efub.livin.global.domain.BaseEntity;
 import com.efub.livin.house.dto.request.HouseCreateRequest;
 import com.efub.livin.review.domain.HouseReview;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 import org.hibernate.annotations.ColumnDefault;
 
 import java.util.ArrayList;
@@ -15,6 +12,8 @@ import java.util.List;
 
 @Entity
 @Getter @Setter
+@Builder
+@AllArgsConstructor
 @Table(name = "house")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class House extends BaseEntity {
@@ -63,34 +62,6 @@ public class House extends BaseEntity {
         this.floor = floor;
         this.elevator = elevator;
         this.parking = parking;
-    }
-
-    // Document dto -> House 엔티티로 변환
-    public static House from(Document dto, HouseType type, String imageUrl){
-        House house = new House();
-        house.buildingName = dto.getPlace_name();
-        house.address = dto.getAddress_name();
-        house.phone = dto.getPhone();
-        house.lon = dto.getX();
-        house.lat = dto.getY();
-        house.docId = dto.getId();
-        house.type = type;
-        house.imageUrl = imageUrl;
-        return house;
-    }
-
-    // 새 자취/하숙 데이터 저장용
-    public static House create(HouseCreateRequest request, String lon, String lat){
-        House house = new House();
-        house.type = request.getType();
-        house.buildingName = request.getBuildingName();
-        house.address = request.getAddress();
-        house.options = request.getOptions();
-        house.parking = request.getParking();
-        house.imageUrl = request.getImageUrl();
-        house.lon = lon;
-        house.lat = lat;
-        return house;
     }
 
 }

--- a/src/main/java/com/efub/livin/house/dto/request/HouseCreateRequest.java
+++ b/src/main/java/com/efub/livin/house/dto/request/HouseCreateRequest.java
@@ -1,5 +1,6 @@
 package com.efub.livin.house.dto.request;
 
+import com.efub.livin.house.domain.House;
 import com.efub.livin.house.domain.HouseType;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -20,5 +21,22 @@ public class HouseCreateRequest {
     private Boolean parking;
     private String options;
     private String imageUrl;
+    private Integer floor;
+    private Boolean elevator;
+
+    public House toEntity(String lon, String lat) {
+        return House.builder()
+                .type(this.type)
+                .buildingName(this.buildingName)
+                .address(this.address)
+                .parking(this.parking)
+                .elevator(this.elevator)
+                .floor(this.floor)
+                .options(this.options)
+                .imageUrl(this.imageUrl)
+                .lon(lon)
+                .lat(lat)
+                .build();
+    }
 
 }

--- a/src/main/java/com/efub/livin/house/dto/response/HouseResponse.java
+++ b/src/main/java/com/efub/livin/house/dto/response/HouseResponse.java
@@ -4,10 +4,14 @@ import com.efub.livin.house.domain.House;
 import com.efub.livin.house.domain.HouseType;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
+@Builder
+@AllArgsConstructor
 @NoArgsConstructor
 public class HouseResponse {
 
@@ -15,26 +19,32 @@ public class HouseResponse {
     private String buildingName;
     private String address;
     private Boolean parking;
+    private Boolean elevator;
+    private Integer floor;
     private HouseType type;
     private String options;
-    private String x; // 경도
-    private String y; // 위도
+    private String lon; // 경도
+    private String lat; // 위도
     private String imageUrl;
+    private String place_url;
+    private String phone;
     private boolean isBookmarked;   // 북마크 여부
 
     public static HouseResponse from(House house, boolean isBookmarked){
-        HouseResponse response = new HouseResponse();
-        response.houseId = house.getHouseId();
-        response.buildingName = house.getBuildingName();
-        response.address = house.getAddress();
-        response.type = house.getType();
-        response.parking = house.getParking();
-        response.options = house.getOptions();
-        response.x = house.getLon(); // 경도
-        response.y = house.getLat(); // 위도
-        response.imageUrl = house.getImageUrl();
-        response.isBookmarked = isBookmarked;
-        return response;
+        return HouseResponse.builder()
+                .houseId(house.getHouseId())
+                .buildingName(house.getBuildingName())
+                .address(house.getAddress())
+                .parking(house.getParking())
+                .elevator(house.getElevator())
+                .floor(house.getFloor())
+                .type(house.getType())
+                .options(house.getOptions())
+                .lon(house.getLon())
+                .lat(house.getLat())
+                .imageUrl(house.getImageUrl())
+                .isBookmarked(isBookmarked)
+                .build();
     }
 
     // 북마크 정보 필요 없는 경우

--- a/src/main/java/com/efub/livin/house/repository/HouseSaveRepository.java
+++ b/src/main/java/com/efub/livin/house/repository/HouseSaveRepository.java
@@ -4,4 +4,6 @@ import com.efub.livin.house.domain.House;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface HouseSaveRepository extends JpaRepository<House, Long> {
+    // 해당 주소가 이미 존재하는지 확인
+    boolean existsByAddress(String address);
 }

--- a/src/main/java/com/efub/livin/house/service/HouseDetailService.java
+++ b/src/main/java/com/efub/livin/house/service/HouseDetailService.java
@@ -1,0 +1,161 @@
+package com.efub.livin.house.service;
+
+import com.efub.livin.global.exception.CustomException;
+import com.efub.livin.global.exception.ErrorCode;
+import com.efub.livin.house.domain.House;
+import com.efub.livin.house.repository.HouseSaveRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.io.*;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class HouseDetailService {
+
+    private final HouseSaveRepository houseRepository;
+
+    // 환경변수 여러 파일 경로
+    @Value("${house.data.csv-paths}")
+    private List<String> csvPaths;
+
+    // House의 상세 정보(엘베, 주차 여부, 층 수) 받아오기
+    @Transactional
+    public void updateDetailsFromCsv() {
+        // DB에 저장된 집들을 다 가져옴
+        List<House> houses = houseRepository.findAll();
+
+        // 검색 속도를 위해 Map으로 변환 (Key: 정제된 주소)
+        Map<String, House> houseMap = mapHousesByAddress(houses);
+
+        log.info("상세 정보 업데이트 대상: {}건", houseMap.size());
+
+        // 파일 목록 순회
+        for (String path : csvPaths) {
+            processSingleCsvFile(path.trim(), houseMap);
+        }
+
+        log.info("모든 CSV 상세 정보 업데이트 완료");
+    }
+
+    // 파일 처리하며 자취/하숙 검색
+    private void processSingleCsvFile(String filePath, Map<String, House> houseMap) {
+        log.info("파일 처리 시작: {}", filePath);
+
+        try (BufferedReader br = openCsvReader(filePath)) {
+            String line;
+            br.readLine(); // 첫 줄 스킵
+
+            while ((line = br.readLine()) != null) {
+                processCsvLine(line, houseMap);
+            }
+        } catch (IOException e) {
+            log.error("파일 처리 실패: {}", filePath);
+            throw new CustomException(ErrorCode.FILE_READ_ERROR);
+        }
+    }
+
+    // 각 줄에서 찾기
+    private void processCsvLine(String line, Map<String, House> houseMap) {
+        try {
+
+            // 첫 번째 쉼표 위치 찾기
+            int firstCommaIndex = line.indexOf(',');
+            if (firstCommaIndex == -1) return;
+
+            // 주소만 빼내기
+            String rawAddress = line.substring(0, firstCommaIndex);
+
+            // 주소 정제 (따옴표 제거 + 정규화)
+            String addressKey = normalizeAddress(removeQuotes(rawAddress));
+
+            // DB에 없는 주소면 버림
+            if (!houseMap.containsKey(addressKey)) {
+                return;
+            }
+
+            // 따옴표 안의 쉼표는 무시하고 자름
+            String[] data = line.split(",(?=([^\"]*\"[^\"]*\")*[^\"]*$)", -1);
+
+            // 데이터 유효성 검사
+            if (data.length < 50) return;
+
+            // 주소 매칭
+            House target = houseMap.get(addressKey);
+
+            // 데이터 파싱
+            // 43번(지상층수, AR), 45번(승용승강기), 46번(비상용승강기), 50~56번(주차장)
+            int floor = parse(data[43]);
+
+            // 엘리베이터 = 승용 + 비상용
+            boolean elevator = (parse(data[45]) + parse(data[46])) > 0;
+
+            // 주차 = 옥내/옥외 기계식 + 옥내/옥외 자주식
+            boolean parking = (parse(data[50]) + parse(data[52]) +
+                    parse(data[54]) + parse(data[56])) > 0;
+
+            // 엔티티 업데이트
+            target.updateSystemInfo(floor, elevator, parking);
+
+        } catch (Exception e) {
+            // 한 줄 건너뛰고 계속 진행
+            log.debug("라인 파싱 실패, 건너뜀: {}", line);
+        }
+    }
+
+    // csv reader 정의
+    private BufferedReader openCsvReader(String filePath) {
+        try {
+            // 공공데이터는 EUC-KR 인코딩 사용
+            return new BufferedReader(new InputStreamReader(new FileInputStream(filePath), "UTF-8"));
+        } catch (FileNotFoundException | UnsupportedEncodingException e) {
+            throw new CustomException(ErrorCode.FILE_NOT_FOUND);
+        }
+    }
+
+    // 주소 정규화
+    private String normalizeAddress(String address) {
+        if (address == null) return "";
+        return address.replaceAll("특별시", "")
+                .replaceAll("광역시", "")
+                .replaceAll("경기도", "")
+                .replaceAll(" ", "")    // 공백 제거
+                .replaceAll("번지", "")  // 번지 제거
+                .trim();
+    }
+
+    // DB 데이터를 Map으로 변환
+    private Map<String, House> mapHousesByAddress(List<House> houses) {
+        Map<String, House> map = new HashMap<>();
+        for (House h : houses) {
+            map.put(normalizeAddress(h.getAddress()), h);
+        }
+        return map;
+    }
+
+    // 공백이나 에러 시 0 반환
+    private int parse(String val) {
+        try {
+            if (val == null || val.trim().isEmpty()) return 0;
+            return Integer.parseInt(val.trim());
+        } catch (NumberFormatException e) {
+            return 0;
+        }
+    }
+
+    // 앞뒤에 붙은 쌍따옴표 제거
+    private String removeQuotes(String str) {
+        if (str == null) return "";
+
+        // 문자열 시작이 " 이면 제거
+        // 문자열 끝이 " 이면 제거
+        return str.replaceAll("^\"|\"$", "").trim();
+    }
+}

--- a/src/main/java/com/efub/livin/house/service/HouseService.java
+++ b/src/main/java/com/efub/livin/house/service/HouseService.java
@@ -36,13 +36,13 @@ public class HouseService {
 
     // 새 자취/하숙 정보 등록
     @Transactional
-    public HouseResponse addHouse(HouseCreateRequest request) {
+    public HouseResponse addHouse(HouseCreateRequest request, User user) {
 
         // 주소 -> 좌표 변환
         Document doc = kakaoApiClient.searchAddress(request.getAddress()).getDocuments().get(0);
 
         // House 저장
-        House house = House.create(request, doc.getX(), doc.getY());
+        House house = request.toEntity(doc.getX(), doc.getY());
         House savedHouse = houseRepository.save(house);
 
         return HouseResponse.from(savedHouse);

--- a/src/main/java/com/efub/livin/house/service/HouseSyncService.java
+++ b/src/main/java/com/efub/livin/house/service/HouseSyncService.java
@@ -37,6 +37,11 @@ public class HouseSyncService {
             }
 
             for(Document document : documents){
+
+                // 이미 존재하는 집이면 넘김
+                if (houseSaveRepository.existsByAddress(document.getAddress_name())){
+                    continue;
+                }
                 HouseType type;
                 String imageUrl = null;
 

--- a/src/main/java/com/efub/livin/house/service/HouseSyncService.java
+++ b/src/main/java/com/efub/livin/house/service/HouseSyncService.java
@@ -64,7 +64,16 @@ public class HouseSyncService {
                     type = BOARDING;
                 }
                 // House 엔티티로 변환
-                House house = House.from(document, type, imageUrl);
+                House house = House.builder()
+                        .buildingName(document.getPlace_name())
+                        .address(document.getAddress_name())
+                        .phone(document.getPhone())
+                        .lon(document.getX())
+                        .lat(document.getY())
+                        .docId(document.getId())
+                        .type(type)
+                        .imageUrl(imageUrl) // 네이버에서 가져온 이미지
+                        .build();
 
                 // DB에 저장
                 houseSaveRepository.save(house);


### PR DESCRIPTION
<!--
name: PR 템플릿
about: PR 생성 시 이 템플릿을 사용해 주세요.
title: "[FEAT]", "[FIX]", ..
-->
## #️⃣ 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요. 
- [x] 국토교통부 csv 파일에서 db에 저장되어있는 자취/하숙의 상세 정보(floor, elevator, parking)을 받아와서 저장
- [x] HouseSyncService에서 데이터 Sync 시 이미 DB에 존재하는 데이터 중복 방지
- [x] 자취/하숙 생성 컨트롤러에서 UserDetails 받아옴
- [x] House 엔티티에 `elevator` 필드 추가
- [x] House 엔티티의 `from()`, `create()` 메서드를 서비스 `builder()`, dto `toEntity()`로 위임
- [x] HouseResponse의 `from()` 을 `builder()` 방식으로 변경
      
## #️⃣ 테스트 내용

> 어떤 테스트를 수행했는지 명시해주세요.  
- [x] Postman 테스트
- [ ] 단위 테스트 수행

## ✅ To-do (선택)
> 작업 예정인 테스크를 작성해주세요.

## 📎 참고 자료 (선택)

> 관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해주세요.

## 📌 연관 이슈

> #이슈번호 
* #3
* Closes #7
* Closes #16
